### PR TITLE
Fixes for Data::MessagePack renovation

### DIFF
--- a/lib/Distribution/Extension/Updater.rakumod
+++ b/lib/Distribution/Extension/Updater.rakumod
@@ -37,7 +37,7 @@ method update-extensions(*@exts where @exts ⊆ @ext) {
     my %updates;
     for @exts || @ext {
         my $new-extension = '.' ~ %ext-updates{$_};
-        for %.ext{$_} -> $file {
+        for %.ext{$_}[] -> $file {
             my $new-file = $file.subst(/\. $_ $/, $new-extension);
             die "Cannot proceed. Duplicate '$new-file' files will be created." if %updates{$new-file};
             %updates{$new-file} = $file if $file;

--- a/lib/Distribution/Extension/Updater.rakumod
+++ b/lib/Distribution/Extension/Updater.rakumod
@@ -48,8 +48,8 @@ method update-extensions(*@exts where @exts ⊆ @ext) {
     my $has-git = self.has-git();
     my $updates-made = False;
     my $meta-content = slurp $!meta.Str;
-    $meta-content ~~ /('"provides"' ':' \s* '{' \s* ('"' .*? '"' \s* ':' \s* '"' .*? '"' \s* ','? \s*)+ '}')/;
-    my $provides = $0.Str;
+    $meta-content ~~ /'"provides"' \s* ':' \s* '{' \s* ['"' .*? '"' \s* ':' \s* '"' .*? '"' \s* ','? \s*]+ '}'/;
+    my $provides = $/.Str;
     my $new-provides = $provides;
     for %updates.keys -> $k {
         my $search = %updates{$k}.Str;


### PR DESCRIPTION
Hello,

this is a combined pull request of two things to make renovation Data::MessagePack work:
- the already mentioned https://github.com/sdondley/Distribution-Extension-Updater/issues/3
- the lack of whitespace support between the "provides" key and the colon, in the META6.json file - I made minor changes with the regex (no need for capture groups here)

I hope it would help to access the most common sources of `rdeu` failures,